### PR TITLE
refactor: Update OpenAddressing HashSet implementation

### DIFF
--- a/src/main/java/dataStructures/hashSet/chaining/HashSet.java
+++ b/src/main/java/dataStructures/hashSet/chaining/HashSet.java
@@ -67,7 +67,7 @@ public class HashSet<T extends Comparable<T>> {
      * @return the number of elements in this set (its cardinality)
      */
     public int size() {
-        return this.size;
+        return size;
     }
 
     /**
@@ -76,13 +76,12 @@ public class HashSet<T extends Comparable<T>> {
      * @return true if this set contains no elements
      */
     public boolean isEmpty() {
-        return this.size() == 0;
+        return size() == 0;
     }
 
     /**
-     * TODO formal documentation.
      * Simple hash function to hash the element into their respective bucket.
-     * Currently uses the division method (k % m).
+     * Currently, uses the division method (k % m).
      * T must override both Object::equals and Object::hashCode.
      *
      * @param element the specified element to be hashed.
@@ -104,12 +103,12 @@ public class HashSet<T extends Comparable<T>> {
      *     element
      */
     public boolean add(T element) {
-        int bucket = this.hashFunction(element);
-        LinkedList<T> bucketLinkedList = this.buckets[bucket];
+        int bucket = hashFunction(element);
+        LinkedList<T> bucketLinkedList = buckets[bucket];
         if (bucketLinkedList.search(element) != -1) {
             return false; // element is already in the set.
         }
-        ++this.size; // updates the cardinality of this hashset.
+        ++size; // updates the cardinality of this hashset.
         return bucketLinkedList.insertFront(element);
     }
 
@@ -120,8 +119,8 @@ public class HashSet<T extends Comparable<T>> {
      * @return true if this set contains the specified element
      */
     public boolean contains(T element) {
-        int bucket = this.hashFunction(element);
-        LinkedList<T> bucketLinkedList = this.buckets[bucket];
+        int bucket = hashFunction(element);
+        LinkedList<T> bucketLinkedList = buckets[bucket];
         return bucketLinkedList.search(element) != -1;
     }
 
@@ -137,14 +136,14 @@ public class HashSet<T extends Comparable<T>> {
      * @return true if this set contained the specified element
      */
     public boolean remove(T element) {
-        int bucket = this.hashFunction(element);
-        LinkedList<T> bucketLinkedList = this.buckets[bucket];
+        int bucket = hashFunction(element);
+        LinkedList<T> bucketLinkedList = buckets[bucket];
         int index = bucketLinkedList.search(element);
         if (index == -1) {
             return false; // If the element is not in the hashset.
         }
         bucketLinkedList.remove(index);
-        --this.size; // updates the cardinality of the hash set.
+        --size; // updates the cardinality of the hash set.
         return true;
     }
 
@@ -155,7 +154,7 @@ public class HashSet<T extends Comparable<T>> {
      */
     public List<T> toList() {
         List<T> outputList = new ArrayList<>();
-        for (LinkedList<T> bucket : this.buckets) {
+        for (LinkedList<T> bucket : buckets) {
             while (bucket.size() != 0) {
                 outputList.add(bucket.pop());
             }

--- a/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
+++ b/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
@@ -165,7 +165,7 @@ public class HashSet<T> {
      * @return true if this HashSet is empty, false otherwise.
      */
     public boolean isEmpty() {
-        return this.size() == 0;
+        return size() == 0;
     }
 
     /**
@@ -174,7 +174,7 @@ public class HashSet<T> {
      * @return the number of elements present in this HashSet.
      */
     public int size() {
-        return this.size;
+        return size;
     }
 
     /**
@@ -195,7 +195,7 @@ public class HashSet<T> {
      * @return the number of buckets of this HashSet.
      */
     public int capacity() {
-        return this.buckets.length; // returns the number of buckets.
+        return buckets.length; // returns the number of buckets.
     }
 
     /**
@@ -252,7 +252,7 @@ public class HashSet<T> {
      * @return true if the bucket at the given index contains no element, false otherwise.
      */
     private boolean isEmptyBucket(int bucketIndex) {
-        return this.isNullBucket(bucketIndex) || this.isTombstoneBucket(bucketIndex);
+        return this.isNullBucket(bucketIndex) || isTombstoneBucket(bucketIndex);
     }
 
     /**
@@ -287,14 +287,14 @@ public class HashSet<T> {
      */
     private void resize(int newCapacity) {
         // creates a temporary reference to the original bucket
-        T[] temp = this.buckets;
+        T[] temp = buckets;
 
         // Safe cast because the only way to add elements into this HashSet is through the add method, which
         // only takes in elements of type T.
         @SuppressWarnings("unchecked")
         T[] newBuckets = (T[]) new Object[newCapacity];
-        this.buckets = newBuckets;
-        this.size = 0;
+        buckets = newBuckets;
+        size = 0;
 
         // re-hashes every element and re-insert into the newly created buckets.
         Arrays.stream(temp)

--- a/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
+++ b/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
@@ -67,11 +67,13 @@ public class HashSet<T> {
             resize(capacity() * 2); // Resize to double the capacity.
         }
 
+        // Number of collisions encountered when attempting to insert the element into its rightful bucket
         int collisions = 0;
         while (collisions < capacity()) {
             int bucketIndex = hashFunction(element, collisions);
 
-            // Insert into empty bucket.
+            // Insert into empty bucket. An empty bucket is defined as one that contains either a
+            // Tombstone, or null.
             if (isEmptyBucket(bucketIndex)) {
                 buckets[bucketIndex] = element;
                 this.size++;
@@ -82,6 +84,10 @@ public class HashSet<T> {
             collisions++;
         }
 
+        // This line will only be reached if the number of empty buckets is zero.
+        // With the resizing mechanism, the HashSet/buckets will expand to a larger capacity when a
+        // certain threshold is reached. This means that there will always be empty buckets for adding of elements.
+        assert false: "should never reach this line under normal circumstances, due to resizing mechanism";
         return false;
     }
 
@@ -112,6 +118,8 @@ public class HashSet<T> {
             int bucketIndex = hashFunction(element, collisions);
 
             // Element is not removed, because it is not in the Set.
+            // Unlike HashSet::add, HashSet::remove ignores buckets containing Tombstones.
+            // Refer to README for a more detailed explanation.
             if (isNullBucket(bucketIndex)) {
                 return false;
             }
@@ -146,6 +154,10 @@ public class HashSet<T> {
             // added to bucket 3 instead of bucket 1, or bucket 2.
             // Similarly, to maintain that invariant, delete will not replace the element with null, but with a
             // marker (Tombstone).
+            // If a bucket contains null in the probe sequence, we can be sure that the Set does not
+            // contain the element, and return false immediately.
+            // Unlike HashSet::add, HashSet::contains ignores buckets containing Tombstones.
+            // Refer to README for a more detailed explanation.
             if (isNullBucket(bucketIndex)) {
                 return false;
             }
@@ -153,6 +165,7 @@ public class HashSet<T> {
             if (buckets[bucketIndex].equals(element)) {
                 return true;
             }
+
             // Skips Tombstones/Deleted elements.
             collisions++;
         }

--- a/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
+++ b/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
@@ -318,7 +318,7 @@ public class HashSet<T> {
         return this.size() >= this.capacity() * LOAD_FACTOR;
     }
 
-    private static <T> T tombstone() {
+    public T tombstone() {
         // It is safe to cast Tombstone to T, because methods retrieving elements (HashSet::get) from the HashSet
         // should, and will check whether the item is a Tombstone object, returning null in-place of the Tombstone.
         @SuppressWarnings("unchecked")

--- a/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
+++ b/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
@@ -87,7 +87,7 @@ public class HashSet<T> {
         // This line will only be reached if the number of empty buckets is zero.
         // With the resizing mechanism, the HashSet/buckets will expand to a larger capacity when a
         // certain threshold is reached. This means that there will always be empty buckets for adding of elements.
-        assert false: "should never reach this line under normal circumstances, due to resizing mechanism";
+        assert false : "should never reach this line under normal circumstances, due to resizing mechanism";
         return false;
     }
 
@@ -318,6 +318,11 @@ public class HashSet<T> {
         return this.size() >= this.capacity() * LOAD_FACTOR;
     }
 
+    /**
+     * Returns the singleton instance of Tombstone. Should never be called outside of tests.
+     *
+     * @return the singleton instance of Tombstone.
+     */
     public T tombstone() {
         // It is safe to cast Tombstone to T, because methods retrieving elements (HashSet::get) from the HashSet
         // should, and will check whether the item is a Tombstone object, returning null in-place of the Tombstone.

--- a/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
+++ b/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
@@ -146,14 +146,6 @@ public class HashSet<T> {
         while (collisions < capacity()) {
             int bucketIndex = hashFunction(element, collisions);
 
-            // Invariant: Probe sequence is unbroken (no null values between buckets in the sequence).
-            // This is maintained by add and delete.
-            // This means that given a probe sequence e.g. (1, 2, 3, 4, 5, ...) for a given element, add will attempt to
-            // add the element into the buckets in the given order. As a result, if an element is in bucket 3, there
-            // will be elements in buckets 1 and 2, given that there must have been collisions for the element to be
-            // added to bucket 3 instead of bucket 1, or bucket 2.
-            // Similarly, to maintain that invariant, delete will not replace the element with null, but with a
-            // marker (Tombstone).
             // If a bucket contains null in the probe sequence, we can be sure that the Set does not
             // contain the element, and return false immediately.
             // Unlike HashSet::add, HashSet::contains ignores buckets containing Tombstones.

--- a/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
+++ b/src/main/java/dataStructures/hashSet/openAddressing/HashSet.java
@@ -76,7 +76,7 @@ public class HashSet<T> {
             // Tombstone, or null.
             if (isEmptyBucket(bucketIndex)) {
                 buckets[bucketIndex] = element;
-                this.size++;
+                size++;
                 return true;
             }
 
@@ -124,7 +124,8 @@ public class HashSet<T> {
                 return false;
             }
 
-            if (buckets[bucketIndex].equals(element)) {
+            if (buckets[bucketIndex].equals(element)
+                && buckets[bucketIndex].hashCode() == element.hashCode()) {
                 buckets[bucketIndex] = tombstone(); // Mark the current bucket with a Tombstone.
                 size--;
                 return true;
@@ -154,7 +155,8 @@ public class HashSet<T> {
                 return false;
             }
 
-            if (buckets[bucketIndex].equals(element)) {
+            if (buckets[bucketIndex].equals(element)
+                && buckets[bucketIndex].hashCode() == element.hashCode()) {
                 return true;
             }
 
@@ -257,7 +259,7 @@ public class HashSet<T> {
      * @return true if the bucket at the given index contains no element, false otherwise.
      */
     private boolean isEmptyBucket(int bucketIndex) {
-        return this.isNullBucket(bucketIndex) || isTombstoneBucket(bucketIndex);
+        return isNullBucket(bucketIndex) || isTombstoneBucket(bucketIndex);
     }
 
     /**
@@ -315,7 +317,7 @@ public class HashSet<T> {
      * @return true if the current load factor is exceeded, false otherwise.
      */
     private boolean isLoadFactorExceeded() {
-        return this.size() >= this.capacity() * LOAD_FACTOR;
+        return size() >= capacity() * LOAD_FACTOR;
     }
 
     /**

--- a/src/main/java/dataStructures/hashSet/openAddressing/README.md
+++ b/src/main/java/dataStructures/hashSet/openAddressing/README.md
@@ -7,16 +7,17 @@ the array (the probe sequence) until either the target element is found, or an u
 which indicates that there is no such key in the table.
 
 ## Implementation Invariant
+
 Note that the buckets are 1-indexed in the following explanation.
 
-Invariant: Probe sequence is unbroken. That is to say, given an element that is initially hashed to 
+Invariant: Probe sequence is unbroken. That is to say, given an element that is initially hashed to
 bucket 1 (arbitrary), the probe sequence {1, 2, ..., m} generated when attempting to `add`/`remove`/`find`
 the element will ***never*** contain null.
 
 This invariant is used to help us ensure the correctness and efficiency of `add`/`remove`/`contains`.
-With the above example of an element generating a probe sequence {1, 2, ...}, `add` will check each bucket 
-sequentially, attempting to add the element, treating buckets containing `Tombstones` (to be explained later) and 
-`nulls` as **empty** buckets available for insertion. 
+With the above example of an element generating a probe sequence {1, 2, ...}, `add` will check each bucket
+sequentially, attempting to add the element, treating buckets containing `Tombstones` (to be explained later) and
+`nulls` as **empty** buckets available for insertion.
 
 As a result, if the bucket is inserted in bucket `m`, such that the probe sequence {1, 2, ..., m} is
 generated, then there must have been elements occupying buckets {1, 2, ..., m - 1}, resulting in collisions.
@@ -26,13 +27,14 @@ simply replacing the element to be removed with `null` will cause `contains` to 
 was present.
 
 `Tombstones` allow us to mark the bucket as deleted, which allows `contains` to know that there is a
-possibility that the targeted element can be found later in the probe sequence, returning false immediately upon 
+possibility that the targeted element can be found later in the probe sequence, returning false immediately upon
 encountering `null`.
 
 We could simply look into every bucket in the sequence, but that will result in `remove` and `contains` having an O(n)
 runtime complexity, defeating the purpose of hashing.
 
-TLDR: There is a need to differentiate between deleted elements, and `nulls` to ensure operations on the Set have an O(1)
+TLDR: There is a need to differentiate between deleted elements, and `nulls` to ensure operations on the Set have an O(
+1)
 time complexity.
 
 ## Probing Strategies
@@ -80,10 +82,12 @@ For n items, in a table of size m, assuming uniform hashing, the expected cost o
 e.g. if α = 90%, then E[#probes] = 10;
 
 ## Properties of Good Hash Functions
+
 There are two properties to measure the "goodness" of a Hash Function
+
 1. h(key, i) enumerates all possible buckets.
-   - For every bucket j, there is some i such that: h(key, i) = j
-   - The hash function is a permutation of {1..m}.
+    - For every bucket j, there is some i such that: h(key, i) = j
+    - The hash function is a permutation of {1..m}.
 
 Linear probing satisfies the first property, because it will probe all possible buckets in the Set. I.e. if an element
 is initially hashed to bucket 1, in a Set with capacity n, linear probing generates a sequence of {1, 2, ..., n - 1, n},
@@ -96,6 +100,6 @@ enumerating every single bucket.
     - Linear Probing does ***NOT*** fulfil UHA. In linear probing, when a collision occurs, the HashSet handles it by
       checking the next bucket, linearly until an empty bucket is found. The next slot is always determined in a fixed
       linear manner.
-    - In practicality, achieving UHA is difficult. Double hashing can come close to achieving UHA, by using another 
+    - In practicality, achieving UHA is difficult. Double hashing can come close to achieving UHA, by using another
       hash function to vary the step size (unlike linear probe where the step size is constant), resulting in a more
       uniform distribution of keys and better performance for the hash table.

--- a/src/main/java/dataStructures/hashSet/openAddressing/README.md
+++ b/src/main/java/dataStructures/hashSet/openAddressing/README.md
@@ -1,8 +1,10 @@
 # HashSet (Open-addressing)
 
+## Background
+
 Open-addressing is another approach to resolving collisions in hash tables.
 
-A hash collision is resolved by <b>probing<b>, or searching through alternative locations in
+A hash collision is resolved by **probing** - searching through alternative locations in
 the array (the probe sequence) until either the target element is found, or an unused array slot is found,
 which indicates that there is no such key in the table.
 
@@ -10,7 +12,9 @@ which indicates that there is no such key in the table.
 
 Note that the buckets are 1-indexed in the following explanation.
 
-Invariant: Probe sequence is unbroken. That is to say, given an element that is initially hashed to
+Invariant: ***Probe sequence is unbroken.***
+
+That is to say, given an element that is initially hashed to
 bucket 1 (arbitrary), the probe sequence {1, 2, ..., m} generated when attempting to `add`/`remove`/`find`
 the element will ***never*** contain null.
 
@@ -33,11 +37,26 @@ encountering `null`.
 We could simply look into every bucket in the sequence, but that will result in `remove` and `contains` having an O(n)
 runtime complexity, defeating the purpose of hashing.
 
-TLDR: There is a need to differentiate between deleted elements, and `nulls` to ensure operations on the Set have an O(
-1)
-time complexity.
+TLDR: There is a need to differentiate between deleted elements, and `nulls` to ensure operations on the Set have an
+O(1) time complexity.
 
 ## Probing Strategies
+
+For Open-Addressing, the hash function differs from that of Chaining, in that the number of collisions encountered
+when inserting the key into the Hash Set is taken into account into determining the hash value.
+
+In the following probe strategies, the hash function typically looks like a variation of:
+<div style="text-align: center;"><code>h(k, i) = (h'(k) + i) mod m</code></div>
+
+`h'(k)` would be the equivalent of a typical hash function used in a HashSet that resolves collisions by Chaining,
+while an additional parameter `i` indicates the number of collisions so far.
+
+Take Linear Probing with a step size of 1 as an example.
+Given an element `k` hashed to bucket 1 initially, such that:
+<div style="text-align: center;"><code>h(k, 0) = 1</code></div>
+
+then, if there was already an element in bucket 1 resulting in a collision, then the next bucket index is determined by:
+<div style="text-align: center;"><code>h(k, 1) = 1 + 1 = 2</code></div>
 
 ### Linear Probing
 
@@ -48,7 +67,8 @@ Simplest form of probing and involves linearly searching the hash table for an e
 However, this method of probing can result in a phenomenon called (primary) clustering where a large run of
 occupied slots builds up, which can drastically degrade the performance of add, remove and contains operations.
 
-h(k, i) = (h'(k) + i) mod m where h'(k) is an ordinary hash function
+`h(k, i) = (h'(k) + i) mod m`
+where `h'(k)` is an ordinary hash function, and `i` is the number of collisions so far.
 
 ### Quadratic Probing
 
@@ -58,35 +78,37 @@ polynomial until an open slot is found.
 This helps to avoid primary clustering of entries (like in Linear Probing), but might still result in secondary
 clustering where keys that hash to the same value probe the same alternative cells when a collision occurs.
 
-h(k, i) = ( h`(k) + c1 * i + c2 * (i^2) ) mod m where c1 and c2 are arbitrary constants
+`h(k, i) = (h'(k) + c1 * i + c2 * (i^2)) mod m` where `c1` and `c2` are arbitrary constants
 
 ### Double Hashing
 
 This is a method of probing where a secondary hash function is used for probing whenever a collision occurs.
 
-If h2(k) is relatively prime to m for all k, Uniform Hashing Assumption can hold true, as all permutations of probe
-sequences occur in equal probability.
+If `h2(k)` is relatively prime to `m` for all `k`, Uniform Hashing Assumption can hold true, as all permutations of
+probe sequences occur in equal probability.
 
-h(k, i) = (h1(k) + i * h2(k)) mod m where h1(k) and h2(k) are two ordinary hash functions
+`h(k, i) = (h1(k) + i * h2(k)) mod m` where `h1(k)` and `h2(k)` are two ordinary hash functions
 
 *Source: https://courses.csail.mit.edu/6.006/fall11/lectures/lecture10.pdf*
 
 ## Complexity Analysis
 
-let α = n / m where α is the load factor of the table
+let `α = n / m` where `α` is the load factor of the table
 
-For n items, in a table of size m, assuming uniform hashing, the expected cost of an operation is:
+For `n` items, in a table of size `m`, assuming uniform hashing, the expected cost of an operation is:
 
-<div style="text-align: center;">1/1-α</div>
+<div style="text-align: center;"><code>1/1-α</code></div>
 
-e.g. if α = 90%, then E[#probes] = 10;
+e.g. if `α` = 90%, then `E[#probes]` = 10;
 
-## Properties of Good Hash Functions
+## Notes
+
+### Properties of Good Hash Functions
 
 There are two properties to measure the "goodness" of a Hash Function
 
-1. h(key, i) enumerates all possible buckets.
-    - For every bucket j, there is some i such that: h(key, i) = j
+1. `h(key, i)` enumerates all possible buckets.
+    - For every bucket `j`, there is some `i` such that: `h(key, i) = j`
     - The hash function is a permutation of {1..m}.
 
 Linear probing satisfies the first property, because it will probe all possible buckets in the Set. I.e. if an element

--- a/src/main/java/dataStructures/hashSet/openAddressing/README.md
+++ b/src/main/java/dataStructures/hashSet/openAddressing/README.md
@@ -6,6 +6,35 @@ A hash collision is resolved by <b>probing<b>, or searching through alternative 
 the array (the probe sequence) until either the target element is found, or an unused array slot is found,
 which indicates that there is no such key in the table.
 
+## Implementation Invariant
+Note that the buckets are 1-indexed in the following explanation.
+
+Invariant: Probe sequence is unbroken. That is to say, given an element that is initially hashed to 
+bucket 1 (arbitrary), the probe sequence {1, 2, ..., m} generated when attempting to `add`/`remove`/`find`
+the element will ***never*** contain null.
+
+This invariant is used to help us ensure the correctness and efficiency of `add`/`remove`/`contains`.
+With the above example of an element generating a probe sequence {1, 2, ...}, `add` will check each bucket 
+sequentially, attempting to add the element, treating buckets containing `Tombstones` (to be explained later) and 
+`nulls` as **empty** buckets available for insertion. 
+
+As a result, if the bucket is inserted in bucket `m`, such that the probe sequence {1, 2, ..., m} is
+generated, then there must have been elements occupying buckets {1, 2, ..., m - 1}, resulting in collisions.
+
+`remove` maintains this invariant with the help of a `Tombstone` class. As explained in the CS2040S lecture notes,
+simply replacing the element to be removed with `null` will cause `contains` to **fail** to find an element, even if it
+was present.
+
+`Tombstones` allow us to mark the bucket as deleted, which allows `contains` to know that there is a
+possibility that the targeted element can be found later in the probe sequence, returning false immediately upon 
+encountering `null`.
+
+We could simply look into every bucket in the sequence, but that will result in `remove` and `contains` having an O(n)
+runtime complexity, defeating the purpose of hashing.
+
+TLDR: There is a need to differentiate between deleted elements, and `nulls` to ensure operations on the Set have an O(1)
+time complexity.
+
 ## Probing Strategies
 
 ### Linear Probing
@@ -40,7 +69,7 @@ h(k, i) = (h1(k) + i * h2(k)) mod m where h1(k) and h2(k) are two ordinary hash 
 
 *Source: https://courses.csail.mit.edu/6.006/fall11/lectures/lecture10.pdf*
 
-## Analysis
+## Complexity Analysis
 
 let α = n / m where α is the load factor of the table
 
@@ -50,3 +79,23 @@ For n items, in a table of size m, assuming uniform hashing, the expected cost o
 
 e.g. if α = 90%, then E[#probes] = 10;
 
+## Properties of Good Hash Functions
+There are two properties to measure the "goodness" of a Hash Function
+1. h(key, i) enumerates all possible buckets.
+   - For every bucket j, there is some i such that: h(key, i) = j
+   - The hash function is a permutation of {1..m}.
+
+Linear probing satisfies the first property, because it will probe all possible buckets in the Set. I.e. if an element
+is initially hashed to bucket 1, in a Set with capacity n, linear probing generates a sequence of {1, 2, ..., n - 1, n},
+enumerating every single bucket.
+
+2. Uniform Hashing Assumption (NOT SUHA)
+    - Every key is equally likely to be mapped to every ***permutation***, independent of every other key.
+    - Under this assumption, the probe sequence should be randomly, and uniformly distributed among all possible
+      permutations, implying `n!` permutations for a probe sequence of size `n`.
+    - Linear Probing does ***NOT*** fulfil UHA. In linear probing, when a collision occurs, the HashSet handles it by
+      checking the next bucket, linearly until an empty bucket is found. The next slot is always determined in a fixed
+      linear manner.
+    - In practicality, achieving UHA is difficult. Double hashing can come close to achieving UHA, by using another 
+      hash function to vary the step size (unlike linear probe where the step size is constant), resulting in a more
+      uniform distribution of keys and better performance for the hash table.

--- a/src/test/java/dataStructures/hashSet/openAddressing/HashSetTest.java
+++ b/src/test/java/dataStructures/hashSet/openAddressing/HashSetTest.java
@@ -2,6 +2,7 @@ package dataStructures.hashSet.openAddressing;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -136,5 +137,21 @@ public class HashSetTest {
         List<Integer> actualList = hashSet.toList();
 
         assertEquals(expectedList, actualList);
+    }
+
+    @Test
+    public void testTombstoneEquals() {
+        HashSet<Integer> integerHashSet = new HashSet<>();
+        assertNotEquals(Integer.valueOf(5), integerHashSet.tombstone());
+        assertNotEquals(null, integerHashSet.tombstone());
+
+        HashSet<Boolean> booleanHashSet = new HashSet<>();
+        assertNotEquals(Boolean.TRUE, booleanHashSet.tombstone());
+        assertNotEquals(Boolean.FALSE, booleanHashSet.tombstone());
+        assertNotEquals(null, booleanHashSet.tombstone());
+
+        HashSet<Object> objectHashSet = new HashSet<>();
+        assertNotEquals(new Object(), objectHashSet.tombstone());
+        assertNotEquals(null, objectHashSet.tombstone());
     }
 }


### PR DESCRIPTION
1. Update private Tombstone class to align with CS2030S Maybe's implementation as much as possible. This is to reduce cognitive overhead when reading the implementation, assuming students are taking CS2030S along with CS2040S.

2. Update implementation of hashFunction to align with CS2040S. Previously, the hashFunction simply calculated a hash, and the probe sequence will then be generated by the linearProbe function. Similarly, a search function that was mostly the same as that of the linearProbe function was implemeneted to deal with null/tombstone buckets differently. This was not a good implementation, because of: - Naming - Tightly coupled methods The refactored hashFunction and linearProbe now takes in an extra parameter: collisions, and is easily extensible by changing a few LoCs.

NOTE:
  The probeSequence generated by the hashFunction and linearProbe is not
  a "good" hash function as defined by CS2040S. While the hashFunction
  enumerates ALL possible buckets, the sequence is NOT a permutation of
  {1...m} where m is the number of buckets.